### PR TITLE
Fix PaulStoffregen/TimeAlarms#3

### DIFF
--- a/TimeAlarms.h
+++ b/TimeAlarms.h
@@ -25,13 +25,14 @@ typedef struct  {
 typedef enum  {dtNotAllocated, dtTimer, dtExplicitAlarm, dtDailyAlarm, dtWeeklyAlarm, dtLastAlarmType } dtAlarmPeriod_t ; // in future: dtBiweekly, dtMonthly, dtAnnual
 
 // macro to return true if the given type is a time based alarm, false if timer or not allocated
-#define dtIsAlarm(_type_)  (_type_ >= dtExplicitAlarm && _type_ < dtLastAlarmType) 
+#define dtIsAlarm(_type_)  (_type_ >= dtExplicitAlarm && _type_ < dtLastAlarmType)
+#define dtUseAbsoluteValue(_type_)  (_type_ == dtTimer || _type_ == dtExplicitAlarm)
 
 typedef uint8_t AlarmID_t;
 typedef AlarmID_t AlarmId;  // Arduino friendly name
 
 #define dtINVALID_ALARM_ID 255
-#define dtINVALID_TIME     0L
+#define dtINVALID_TIME     (time_t)(-1)
 
 class AlarmClass;  // forward reference
 typedef void (*OnTick_t)();  // alarm callback function typedef 
@@ -94,11 +95,12 @@ public:
   void write(AlarmID_t ID, time_t value);   // write the value (and enable) the alarm with the given ID  
   time_t read(AlarmID_t ID);                // return the value for the given timer  
   dtAlarmPeriod_t readType(AlarmID_t ID);   // return the alarm type for the given alarm ID 
-  
+
+  void free(AlarmID_t ID);                  // free the id to allow its reuse 
+
 #ifndef USE_SPECIALIST_METHODS  
 private:  // the following methods are for testing and are not documented as part of the standard library
 #endif
-  void free(AlarmID_t ID);                  // free the id to allow its reuse 
   uint8_t count();                          // returns the number of allocated timers
   time_t getNextTrigger();                  // returns the time of the next scheduled alarm
   bool isAllocated(AlarmID_t ID);           // returns true if this id is allocated  


### PR DESCRIPTION
This fix the issue where alarms set to go off at Midnight (on a daily or weekly basis)
will fail and act as if the alarm is disabled.

Note that the definition of "dtINVALID_TIME" changed (see below).

The following changes have been made to TimeAlarms.cpp:
-AlarmClass::updateNextTrigget(): Only rely on Mode.isEnabled to determine if enabled
or not (no longer check value as it is redundent)
-TimeAlarmsClass::enable(): Changed how a valid alarm is checked to allow for a value
of 0 only on alarms that should accept it
-TimeAlarmsClass::enable(): Now the alarm is disabled if we don't have safe conditions to
enable it
-TimeAlarmsClass::free(): When freeing an alarm, we set .onTickHandler to NULL to avoid
confusion
-TimeAlarmsClass::create(): Changed how a valid alarm is checked to allow for a value of 0
only on alarms that should accept it

The following changes have been made to TimeAlarms.h:
-Add macro: dtUseAbsoluteValue to simplify checking of the value parameter
-dtINVALID_TIME: Change definition from 0 to (time_t)(-1) as now a value of 0 can be
valid. Now the highest possible value is used.
-move 'TimeAlarmsClass::free()' to the public portion of the class so we can always use it
to properly free alarms.