### PR TITLE
Guarantee that serviceAlarms() is called on a delay(0)

### DIFF
--- a/TimeAlarms.cpp
+++ b/TimeAlarms.cpp
@@ -189,9 +189,9 @@ AlarmID_t TimeAlarmsClass::getTriggeredAlarmId()
 void TimeAlarmsClass::delay(unsigned long ms)
 {
   unsigned long start = millis();
-  while (millis() - start  <= ms) {
+  do {
     serviceAlarms();
-  }
+  } while (millis() - start  <= ms);
 }
 
 void TimeAlarmsClass::waitForDigits( uint8_t Digits, dtUnits_t Units)


### PR DESCRIPTION
This is a bit of a micro-optimisation, but there's a small chance that calling `delay(0)` (in a non-blocking piece of code for example) will not result in a call to `serviceAlarms()`.

Using a do-while loop guarantees that `serviceAlarms()` will be called at least once and removes an unnecessary extra call to the `millis()` function.