### PR TITLE
limit waiting in delay function of TimeAlarm lib to 500ms

### DIFF
--- a/TimeAlarms.cpp
+++ b/TimeAlarms.cpp
@@ -189,8 +189,12 @@ AlarmID_t TimeAlarmsClass::getTriggeredAlarmId()
 void TimeAlarmsClass::delay(unsigned long ms)
 {
   unsigned long start = millis();
-  while (millis() - start  <= ms) {
+  while (millis() - start  <= (ms > 500 ? 500 : ms)) {
     serviceAlarms();
+  }
+  // do waiting over delay() function, else watchdog will be triggered
+  if(ms > 500) {
+    delay(ms - 500);
   }
 }
 


### PR DESCRIPTION
limit waiting in delay function of TimeAlarm lib to 500ms, else soft watchdog will be triggered.

delays greater than 500ms will be delayed by internal delay function.