### PR TITLE
improve delay() method; fixes issue #21

### DIFF
--- a/TimeAlarms.cpp
+++ b/TimeAlarms.cpp
@@ -189,9 +189,9 @@ AlarmID_t TimeAlarmsClass::getTriggeredAlarmId()
 void TimeAlarmsClass::delay(unsigned long ms)
 {
   unsigned long start = millis();
-  while (millis() - start  <= ms) {
+  do {
     serviceAlarms();
-  }
+  } while (millis() - start  <= ms);
 }
 
 void TimeAlarmsClass::waitForDigits( uint8_t Digits, dtUnits_t Units)

--- a/TimeAlarms.cpp
+++ b/TimeAlarms.cpp
@@ -191,6 +191,7 @@ void TimeAlarmsClass::delay(unsigned long ms)
   unsigned long start = millis();
   do {
     serviceAlarms();
+    yield();
   } while (millis() - start  <= ms);
 }
 


### PR DESCRIPTION
Hi, this pull request includes
- the fix by Andrew Carter to make sure that delay() services the alarms at least once
- a one-line fix to prevent the watchdog timer on an ESP8266 from triggering:
a simple call to yield() is sufficient to let the ESP8266 do all of its background work, including handling the watchdog timer. Actually, on ESP8266, it's equivalent to delay(0) where the ESP8266 delay() does the right thing by default. On AVR arduinos this is a harmless empty function.
I (quickly) tested the code on an Arduini Mini Pro and a Wemos D1 Mini (ESP8266).