### PR TITLE
Adding Time dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,5 +12,11 @@
 {
     "type": "git",
     "url": "https://github.com/PaulStoffregen/TimeAlarms"
-}
+},
+"dependencies": [
+    {
+      "name": "Time",
+      "version": "^1.6.0"
+    }
+]
 }


### PR DESCRIPTION
When using PlatformIO, the Time (TimeLib.h) library wasn't automatically pulled.
Adding the dependency in the library.json file fixed this for me.